### PR TITLE
Updates

### DIFF
--- a/examples/RiftApp.py
+++ b/examples/RiftApp.py
@@ -1,0 +1,179 @@
+import ovr
+import pygame
+import pygame.locals as pgl
+
+from OpenGL.GL import *
+
+class RiftApp():
+  def __init__(self):
+    print("Hello")
+    ovr.initialize(None)
+    self.hmd, self.luid = ovr.create()
+    self.hmdDesc = ovr.getHmdDesc(self.hmd)
+    self.frame = 0
+    # Workaround for a race condition bug in the SDK
+    import time
+    time.sleep(0.1)
+
+    # print "Rift screen size = ", self.hmdDesc.Resolution        
+    ovr.configureTracking(self.hmd, 
+        ovr.TrackingCap_Orientation | # supported capabilities
+        ovr.TrackingCap_MagYawCorrection |
+        ovr.TrackingCap_Position, 
+        0) # required capabilities
+
+    self.fovPorts = (
+      self.hmdDesc.DefaultEyeFov[0],
+      self.hmdDesc.DefaultEyeFov[1]
+    )
+
+    projections = map(
+      lambda fovPort:
+        (ovr.matrix4f_Projection(
+           fovPort, 0.01, 1000, True)),
+      self.fovPorts
+    )
+    self.projections = map(
+      lambda pr:
+        pr.toList(),
+      projections)
+
+  def close(self):
+    glDeleteFramebuffers(1, self.fbo)
+    glDeleteTextures(self.color)
+    glDeleteRenderbuffers(1, self.depth)
+
+    self.hmd.destroy()
+    self.hmd = None
+    ovr.Hmd.shutdown()
+
+  def create_window(self):
+    import os
+    os.environ['SDL_VIDEO_WINDOW_POS'] = "%d,%d" % (100, 100)
+    pygame.init()
+    pygame.display.set_mode(
+      (
+        self.hmdDesc.Resolution.w / 4,
+        self.hmdDesc.Resolution.h / 4
+      ),
+      pgl.HWSURFACE | pgl.OPENGL | pgl.NOFRAME)
+
+  def init_gl(self):
+
+    recommenedTex0Size = ovr.getFovTextureSize(self.hmd, ovr.Eye_Left, 
+            self.hmdDesc.DefaultEyeFov[0], 1.0)
+    
+    recommenedTex1Size = ovr.getFovTextureSize(self.hmd, ovr.Eye_Right,
+            self.hmdDesc.DefaultEyeFov[1], 1.0)
+    self.bufferSize = ovr.Sizei()
+    self.bufferSize.w  = recommenedTex0Size.w + recommenedTex1Size.w
+    self.bufferSize.h = max ( recommenedTex0Size.h, recommenedTex1Size.h )
+    print "Recommended buffer size = ", self.bufferSize, self.bufferSize.w, self.bufferSize.h
+    # NOTE: We need to have set up OpenGL context before this point...
+    # 1c) Allocate SwapTextureSets
+    self.pTextureSet = ovr.createSwapTextureSetGL(self.hmd,
+            GL_RGBA8, self.bufferSize.w, self.bufferSize.h)
+
+    # Initialize our single full screen Fov layer.
+    layer = ovr.LayerEyeFov()
+    layer.Header.Type      = ovr.LayerType_EyeFov
+    layer.Header.Flags     = ovr.LayerFlag_TextureOriginAtBottomLeft # OpenGL convention
+    layer.ColorTexture[0]  = self.pTextureSet # single texture for both eyes
+    layer.ColorTexture[1]  = self.pTextureSet # single texture for both eyes
+    layer.Fov[0]           = self.fovPorts[0]
+    layer.Fov[1]           = self.fovPorts[1]
+    layer.Viewport[0]      = ovr.Recti(ovr.Vector2i(0, 0), ovr.Sizei(self.bufferSize.w / 2, self.bufferSize.h))
+    layer.Viewport[1]      = ovr.Recti(ovr.Vector2i(self.bufferSize.w / 2, 0), ovr.Sizei(self.bufferSize.w / 2, self.bufferSize.h))
+    self.layer = layer
+
+    self.build_framebuffer();
+
+    self.eyeRenderDescs = [ ovr.EyeRenderDesc(), ovr.EyeRenderDesc() ];
+    self.eyeOffsets = (ovr.Vector3f * 2)();
+    for eye in range(0, 2):
+      self.eyeRenderDescs[eye] = ovr.getRenderDesc(self.hmd, eye, self.fovPorts[eye]);
+      self.eyeOffsets[eye] = self.eyeRenderDescs[eye].HmdToEyeViewOffset
+      
+  def build_framebuffer(self):
+    self.fbo = glGenFramebuffers(1)
+    self.depth = glGenRenderbuffers(1)
+    # Set up the depth attachment renderbuffer
+    glBindRenderbuffer(GL_RENDERBUFFER, self.depth)
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, 
+                          self.bufferSize.w, self.bufferSize.h)
+    glBindRenderbuffer(GL_RENDERBUFFER, 0)
+
+    # Set up the framebuffer proper
+    glBindFramebuffer(GL_FRAMEBUFFER, self.fbo)
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, self.depth)
+    glBindFramebuffer(GL_FRAMEBUFFER, 0)
+
+  def bind_framebuffer(self):
+      glBindFramebuffer(GL_FRAMEBUFFER, self.fbo)
+      tsc = self.pTextureSet.contents
+      texture = ctypes.cast(ctypes.addressof(tsc.Textures[tsc.CurrentIndex]), ctypes.POINTER(ovr.GLTexture)).contents
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture.OGL.TexId, 0)
+      fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER)
+      if (GL_FRAMEBUFFER_COMPLETE != fboStatus):
+        raise Exception("Bad framebuffer setup")
+  
+  def increment_framebuffer(self): 
+    tsc = self.pTextureSet.contents
+    tsc.CurrentIndex = (tsc.CurrentIndex + 1) % tsc.TextureCount
+
+  def submit_frame(self): 
+    layers = self.layer.Header
+    viewScale = ovr.ViewScaleDesc()
+    viewScale.HmdSpaceToWorldScaleInMeters = 1.0
+    for eye in range(0, 2):
+      self.layer.RenderPose[eye] = self.poses[eye]
+      viewScale.HmdToEyeViewOffset[eye] = self.eyeOffsets[eye]
+    result = ovr.submitFrame(self.hmd, self.frame, viewScale, layers, 1)
+
+  def render_frame(self):
+    self.frame += 1
+
+    # Fetch the head pose
+    self.poses = (ovr.Posef * 2)()
+    ovr.getEyePoses(self.hmd, self.frame, self.eyeOffsets, self.poses)
+
+    # Active the offscreen framebuffer and render the scene
+    self.bind_framebuffer()
+
+    for eye in range(0, 2):
+      self.currentEye = eye;
+      vp = self.layer.Viewport[eye]
+      glViewport(vp.Pos.x, vp.Pos.y, vp.Size.w, vp.Size.h)
+      glEnable(GL_SCISSOR_TEST)
+      glScissor(vp.Pos.x, vp.Pos.y, vp.Size.w, vp.Size.h)
+      self.render_scene()
+
+    self.currentEye = -1;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0)
+    self.submit_frame();
+    self.increment_framebuffer();
+    glGetError()
+
+  def update(self):
+    for event in pygame.event.get():
+      self.on_event(event)
+
+  def on_event(self, event):
+    if event.type == pgl.QUIT:
+      self.running = False
+      return True
+    if event.type == pgl.KEYUP and event.key == pgl.K_ESCAPE:
+      self.running = False
+      return True
+    return False
+
+  def run(self):
+    self.create_window()
+    self.init_gl()
+    self.running = True
+    while self.running:
+      self.update()
+      self.render_frame()
+      #pygame.display.flip()
+    self.close()
+    pygame.quit()

--- a/examples/RiftApp.py
+++ b/examples/RiftApp.py
@@ -6,16 +6,11 @@ from OpenGL.GL import *
 
 class RiftApp():
   def __init__(self):
-    print("Hello")
     ovr.initialize(None)
     self.hmd, self.luid = ovr.create()
     self.hmdDesc = ovr.getHmdDesc(self.hmd)
     self.frame = 0
-    # Workaround for a race condition bug in the SDK
-    import time
-    time.sleep(0.1)
 
-    # print "Rift screen size = ", self.hmdDesc.Resolution        
     ovr.configureTracking(self.hmd, 
         ovr.TrackingCap_Orientation | # supported capabilities
         ovr.TrackingCap_MagYawCorrection |
@@ -27,16 +22,12 @@ class RiftApp():
       self.hmdDesc.DefaultEyeFov[1]
     )
 
-    projections = map(
+    self.projections = map(
       lambda fovPort:
         (ovr.matrix4f_Projection(
            fovPort, 0.01, 1000, True)),
       self.fovPorts
     )
-    self.projections = map(
-      lambda pr:
-        pr.toList(),
-      projections)
 
   def close(self):
     glDeleteFramebuffers(1, self.fbo)

--- a/examples/RiftDemo.py
+++ b/examples/RiftDemo.py
@@ -74,7 +74,7 @@ class RiftDemo(RiftApp):
   def __init__(self):
     RiftApp.__init__(self)
     self.cube_size = ovr.getFloat(self.hmd, 
-      ovr.OVR_KEY_IPD, ovr.OVR_DEFAULT_IPD)
+      ovr.KEY_IPD, ovr.DEFAULT_IPD)
     self.reset_camera()
     
   def reset_camera(self):
@@ -132,19 +132,19 @@ class RiftDemo(RiftApp):
   def render_scene(self):
     eye = self.currentEye;
 
-    # apply it to the eyeview matrix
     eyeview = ovrPoseToMat4(self.poses[eye])
   
     # apply the camera position
     cameraview = self.camera * eyeview  
 
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
     glMatrixMode(GL_PROJECTION)
-    glLoadMatrixf(self.projections[eye])
+    glLoadMatrixf(self.projections[eye].toList())
+
     glMatrixMode(GL_MODELVIEW)
     glLoadIdentity();
     glLoadMatrixf(cameraview.inverse().toList())
-    #glMultMatrixf(self.camera.inverse().toList())
+
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
     draw_color_cube(self.cube_size)
 
 

--- a/examples/RiftDemo.py
+++ b/examples/RiftDemo.py
@@ -1,0 +1,153 @@
+#! /usr/bin/env python
+import pygame
+import pygame.locals as pgl
+import ovr
+
+from RiftApp import RiftApp
+from cgkit.cgtypes import mat4, vec3, quat
+from OpenGL.GL import *
+
+def ovrPoseToMat4(pose):
+  # Apply the head orientation
+  rot = pose.Orientation
+  # Convert the OVR orientation (a quaternion structure) to a cgkit quaternion 
+  # class, and from there to a mat4  Coordinates are camera coordinates
+  rot = quat(rot.toList())
+  rot = rot.toMat4()
+
+  # Apply the head position
+  pos = pose.Position
+  # Convert the OVR position (a vector3 structure) to a cgcit vector3 class. 
+  # Position is in camera / Rift coordinates
+  pos = vec3(pos.toList())
+  pos = mat4(1.0).translate(pos)
+  
+  pose = pos * rot
+  return pose
+
+
+def draw_color_cube(size=1.0):
+  p = size / 2.0
+  n = -p
+  glBegin(GL_QUADS)
+
+  # front
+  glColor3f(1, 1, 0)
+  glVertex3f(n, n, n)
+  glVertex3f(p, n, n)
+  glVertex3f(p, p, n)
+  glVertex3f(n, p, n)
+  # back
+  glColor3f(0.2, 0.2, 1)
+  glVertex3f(n, n, p)
+  glVertex3f(p, n, p)
+  glVertex3f(p, p, p)
+  glVertex3f(n, p, p)
+  # right
+  glColor3f(1, 0, 0)
+  glVertex3f(p, n, n)
+  glVertex3f(p, n, p)
+  glVertex3f(p, p, p)
+  glVertex3f(p, p, n)
+  # left
+  glColor3f(0, 1, 1)
+  glVertex3f(n, n, n)
+  glVertex3f(n, n, p)
+  glVertex3f(n, p, p)
+  glVertex3f(n, p, n)
+  # top
+  glColor3f(0, 1, 0)
+  glVertex3f(n, p, n)
+  glVertex3f(p, p, n)
+  glVertex3f(p, p, p)
+  glVertex3f(n, p, p)
+  # bottom
+  glColor3f(1, 0, 1)
+  glVertex3f(n, n, n)
+  glVertex3f(p, n, n)
+  glVertex3f(p, n, p)
+  glVertex3f(n, n, p)
+  glEnd()
+
+
+class RiftDemo(RiftApp):
+  def __init__(self):
+    RiftApp.__init__(self)
+    self.cube_size = ovr.getFloat(self.hmd, 
+      ovr.OVR_KEY_IPD, ovr.OVR_DEFAULT_IPD)
+    self.reset_camera()
+    
+  def reset_camera(self):
+    self.camera = mat4(1.0)
+    self.camera.translate(vec3(0, 0, 0.2))
+
+  def recompose_camera(self):
+    (tr, rot, sc) = self.camera.decompose()
+    self.camera = mat4(1.0)
+    self.camera.translate(tr)
+    self.camera = self.camera * rot
+    
+  def init_gl(self):
+    RiftApp.init_gl(self)
+    glEnable(GL_DEPTH_TEST)
+    glClearColor(0.1, 0.1, 0.1, 1)
+
+  def update(self):
+    RiftApp.update(self)
+    pressed = pygame.key.get_pressed()
+
+    if pressed[pgl.K_r]:
+      self.reset_camera()
+
+    rotation = 0.0
+    
+    if pressed[pgl.K_q]:
+      rotation = +1.0
+    if pressed[pgl.K_e]:
+      rotation = -1.0
+    if (rotation != 0.0):
+      self.camera = self.camera * \
+        mat4.rotation(rotation * 0.01, vec3(0, 1, 0))
+      self.recompose_camera()
+       
+    # Modify direction vectors for key presses
+    translation = vec3()
+    if pressed[pgl.K_r]:
+      ovr.recenterPose(self.hmd)
+    if pressed[pgl.K_w]:
+      translation.z = -1.0
+    elif pressed[pgl.K_s]:
+      translation.z = +1.0
+    if pressed[pgl.K_a]:
+      translation.x = -1.0
+    elif pressed[pgl.K_d]:
+      translation.x = +1.0
+    if (vec3.length(translation) > 0.1):
+      translation = self.camera.getMat3() * (translation * 0.005)
+      self.camera.translate(translation)
+      self.recompose_camera()
+
+  
+
+  def render_scene(self):
+    eye = self.currentEye;
+
+    # apply it to the eyeview matrix
+    eyeview = ovrPoseToMat4(self.poses[eye])
+  
+    # apply the camera position
+    cameraview = self.camera * eyeview  
+
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+    glMatrixMode(GL_PROJECTION)
+    glLoadMatrixf(self.projections[eye])
+    glMatrixMode(GL_MODELVIEW)
+    glLoadIdentity();
+    glLoadMatrixf(cameraview.inverse().toList())
+    #glMultMatrixf(self.camera.inverse().toList())
+    draw_color_cube(self.cube_size)
+
+
+RiftDemo().run();
+
+

--- a/examples/glut/glut_renderer.py
+++ b/examples/glut/glut_renderer.py
@@ -29,7 +29,7 @@ class GlutRenderer():
         self.glut_window_width = width
         self.glut_window_height = height
         glutInit()
-        glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE)
+        glutInitDisplayMode(GLUT_RGBA)
         glutInitWindowSize(self.glut_window_width, self.glut_window_height)
         glutInitWindowPosition(50, 50)
         win = glutCreateWindow("Just a triangle")

--- a/ovr/__init__.py
+++ b/ovr/__init__.py
@@ -19,7 +19,7 @@ OVR_PTR_SIZE = ctypes.sizeof(ctypes.c_voidp) # distinguish 32 vs 64 bit python
 # 1) Figure out name of library to load
 _libname = "OVRRT32_0_7" # 32-bit python
 if OVR_PTR_SIZE == 8:
-    _libname = OVRRT64_0_7 # 64-bit python
+    _libname = "OVRRT64_0_7" # 64-bit python
 if platform.system().startswith("Win"):
     _libname = "Lib"+_libname # i.e. "LibOVRRT32_0_7"
 # Load library
@@ -1958,7 +1958,7 @@ def createSwapTextureSetGL(hmd, format, width, height):
 # Translated from header file OVR_CAPI_GL.h line 73
 libovr.ovr_CreateMirrorTextureGL.restype = Result
 libovr.ovr_CreateMirrorTextureGL.argtypes = [Hmd, GLuint, ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.POINTER(Texture))]
-def createMirrorTextureGL(hmd, format, width, height):
+def createMirrorTextureGL(hmd, format_, width, height):
     """
     Creates a Mirror Texture which is auto-refreshed to mirror Rift contents produced by this application.
     
@@ -1984,7 +1984,7 @@ def createMirrorTextureGL(hmd, format, width, height):
     \see ovr_DestroyMirrorTexture
     """
     outMirrorTexture = ctypes.POINTER(Texture)()
-    result = libovr.ovr_CreateMirrorTextureGL(hmd, format, width, height, None if outMirrorTexture is None else byref(outMirrorTexture))
+    result = libovr.ovr_CreateMirrorTextureGL(hmd, format_, width, height, None if outMirrorTexture is None else byref(outMirrorTexture))
     if FAILURE(result):
         raise Exception("Call to function createMirrorTextureGL failed")    
     return outMirrorTexture
@@ -2122,6 +2122,77 @@ def getEyePoses(hmd, frameIndex, hmdToEyeViewOffset, outEyePoses):
 
 
 ### END Declarations from C header file OVR_CAPI_Util.h ###
+
+
+try:
+    OVR_KEY_USER = 'User'
+except:
+    pass
+
+try:
+    OVR_KEY_NAME = 'Name'
+except:
+    pass
+
+try:
+    OVR_KEY_GENDER = 'Gender'
+except:
+    pass
+
+try:
+    OVR_KEY_PLAYER_HEIGHT = 'PlayerHeight'
+except:
+    pass
+
+try:
+    OVR_KEY_EYE_HEIGHT = 'EyeHeight'
+except:
+    pass
+
+try:
+    OVR_KEY_IPD = 'IPD'
+except:
+    pass
+
+try:
+    OVR_KEY_NECK_TO_EYE_DISTANCE = 'NeckEyeDistance'
+except:
+    pass
+
+try:
+    OVR_DEFAULT_GENDER = 'Unknown'
+except:
+    pass
+
+try:
+    OVR_DEFAULT_PLAYER_HEIGHT = 1.778
+except:
+    pass
+
+try:
+    OVR_DEFAULT_EYE_HEIGHT = 1.675
+except:
+    pass
+
+try:
+    OVR_DEFAULT_IPD = 0.064
+except:
+    pass
+
+try:
+    OVR_DEFAULT_NECK_TO_EYE_HORIZONTAL = 0.0805
+except:
+    pass
+
+try:
+    OVR_DEFAULT_NECK_TO_EYE_VERTICAL = 0.075
+except:
+    pass
+
+try:
+    OVR_DEFAULT_EYE_RELIEF_DIAL = 3
+except:
+    pass
 
 
 # Run test program

--- a/ovr/__init__.py
+++ b/ovr/__init__.py
@@ -2447,80 +2447,82 @@ def matrix4f_Projection(fov, znear, zfar, projectionModFlags):
     
     \see ovrProjectionModifier
     """
-    #result = libovr.ovrMatrix4f_Projection(fov, znear, zfar, projectionModFlags)
-    #return result
-    rightHanded    = (projectionModFlags & Projection_RightHanded) > 0
-    flipZ          = (projectionModFlags & Projection_FarLessThanNear) > 0
-    farAtInfinity  = (projectionModFlags & Projection_FarClipAtInfinity) > 0
-    isOpenGL       = (projectionModFlags & Projection_ClipRangeOpenGL) > 0
+    result = libovr.ovrMatrix4f_Projection(fov, znear, zfar, projectionModFlags)
+    return result
 
-    if farAtInfinity and not flipZ :
-        farAtInfinity = False;
-
-    projXScale = 2.0 / ( fov.LeftTan + fov.RightTan )
-    projXOffset = ( fov.LeftTan - fov.RightTan ) * projXScale * 0.5
-    projYScale = 2.0 / ( fov.UpTan + fov.DownTan )
-    projYOffset = ( fov.UpTan - fov.DownTan ) * projYScale * 0.5
-
-    scale = Vector2f(projXScale, projYScale)
-    offset = Vector2f(projXOffset, projYOffset)
-    handednessScale = 1.0
-    if rightHanded:
-      handednessScale = -1.0
-
-    zscale = 1.0
-    if flipZ:
-      zscale = -1.0
-
-    projection = Matrix4f()
-    # Produces X result, mapping clip edges to [-w,+w]
-    projection.M[0][0] = scale.x
-    projection.M[0][1] = 0.0
-    projection.M[0][2] = handednessScale * offset.x
-    projection.M[0][3] = 0.0
-
-    # Produces Y result, mapping clip edges to [-w,+w]
-    # Hey - why is that YOffset negated?
-    # It's because a projection matrix transforms from world coords with Y=up,
-    # whereas this is derived from an NDC scaling, which is Y=down.
-    projection.M[1][0] = 0.0
-    projection.M[1][1] = scale.y
-    projection.M[1][2] = handednessScale * -offset.y
-    projection.M[1][3] = 0.0
-
-    # Produces Z-buffer result - app needs to fill this in with whatever Z range it wants.
-    # We'll just use some defaults for now.
-    projection.M[2][0] = 0.0
-    projection.M[2][1] = 0.0
-
-    if farAtInfinity:
-      if isOpenGL:
-        # It's not clear this makes sense for OpenGL - you don't get the same precision benefits you do in D3D.
-        projection.M[2][2] = -handednessScale
-        projection.M[2][3] = 2.0 * znear
-      else:
-        projection.M[2][2] = 0.0;
-        projection.M[2][3] = znear;
-    else:
-      if isOpenGL:
-        # Clip range is [-w,+w], so 0 is at the middle of the range.
-        projection.M[2][2] = -handednessScale * zscale * (znear + zfar) / (znear - zfar);
-        projection.M[2][3] = 2.0 * zscale * zfar * znear / (znear - zfar);
-      else:
-        # Clip range is [0,+w], so 0 is at the start of the range.
-        near = -znear;
-        if flipZ:
-          near = zfar;
-        projection.M[2][2] = -handednessScale * near / (znear - zfar);
-        projection.M[2][3] = zscale * zfar * znear / (znear - zfar);
-
-    # Produces W result (= Z in)
-    projection.M[3][0] = 0.0;
-    projection.M[3][1] = 0.0;
-    projection.M[3][2] = handednessScale;
-    projection.M[3][3] = 0.0;
-
-    return projection;
+# apparently not needed, don't know why the SDK doesn't use the DLL projection matrix.
+#     rightHanded    = (projectionModFlags & Projection_RightHanded) > 0
+#     flipZ          = (projectionModFlags & Projection_FarLessThanNear) > 0
+#     farAtInfinity  = (projectionModFlags & Projection_FarClipAtInfinity) > 0
+#     isOpenGL       = (projectionModFlags & Projection_ClipRangeOpenGL) > 0
+# 
+#     if farAtInfinity and not flipZ :
+#         farAtInfinity = False;
+# 
+#     projXScale = 2.0 / ( fov.LeftTan + fov.RightTan )
+#     projXOffset = ( fov.LeftTan - fov.RightTan ) * projXScale * 0.5
+#     projYScale = 2.0 / ( fov.UpTan + fov.DownTan )
+#     projYOffset = ( fov.UpTan - fov.DownTan ) * projYScale * 0.5
+# 
+#     scale = Vector2f(projXScale, projYScale)
+#     offset = Vector2f(projXOffset, projYOffset)
+#     handednessScale = 1.0
+#     if rightHanded:
+#       handednessScale = -1.0
+# 
+#     zscale = 1.0
+#     if flipZ:
+#       zscale = -1.0
+# 
+#     projection = Matrix4f()
+#     # Produces X result, mapping clip edges to [-w,+w]
+#     projection.M[0][0] = scale.x
+#     projection.M[0][1] = 0.0
+#     projection.M[0][2] = handednessScale * offset.x
+#     projection.M[0][3] = 0.0
+# 
+#     # Produces Y result, mapping clip edges to [-w,+w]
+#     # Hey - why is that YOffset negated?
+#     # It's because a projection matrix transforms from world coords with Y=up,
+#     # whereas this is derived from an NDC scaling, which is Y=down.
+#     projection.M[1][0] = 0.0
+#     projection.M[1][1] = scale.y
+#     projection.M[1][2] = handednessScale * -offset.y
+#     projection.M[1][3] = 0.0
+# 
+#     # Produces Z-buffer result - app needs to fill this in with whatever Z range it wants.
+#     # We'll just use some defaults for now.
+#     projection.M[2][0] = 0.0
+#     projection.M[2][1] = 0.0
+# 
+#     if farAtInfinity:
+#       if isOpenGL:
+#         # It's not clear this makes sense for OpenGL - you don't get the same precision benefits you do in D3D.
+#         projection.M[2][2] = -handednessScale
+#         projection.M[2][3] = 2.0 * znear
+#       else:
+#         projection.M[2][2] = 0.0;
+#         projection.M[2][3] = znear;
+#     else:
+#       if isOpenGL:
+#         # Clip range is [-w,+w], so 0 is at the middle of the range.
+#         projection.M[2][2] = -handednessScale * zscale * (znear + zfar) / (znear - zfar);
+#         projection.M[2][3] = 2.0 * zscale * zfar * znear / (znear - zfar);
+#       else:
+#         # Clip range is [0,+w], so 0 is at the start of the range.
+#         near = -znear;
+#         if flipZ:
+#           near = zfar;
+#         projection.M[2][2] = -handednessScale * near / (znear - zfar);
+#         projection.M[2][3] = zscale * zfar * znear / (znear - zfar);
+# 
+#     # Produces W result (= Z in)
+#     projection.M[3][0] = 0.0;
+#     projection.M[3][1] = 0.0;
+#     projection.M[3][2] = handednessScale;
+#     projection.M[3][3] = 0.0;
+# 
+#     return projection;
 
 
 # Translated from header file OVR_CAPI_Util.h line 61
@@ -2604,77 +2606,6 @@ def getEyePoses(hmd, frameIndex, hmdToEyeViewOffset, outEyePoses):
 
 
 ### END Declarations from C header file OVR_CAPI_Util.h ###
-
-
-try:
-    OVR_KEY_USER = 'User'
-except:
-    pass
-
-try:
-    OVR_KEY_NAME = 'Name'
-except:
-    pass
-
-try:
-    OVR_KEY_GENDER = 'Gender'
-except:
-    pass
-
-try:
-    OVR_KEY_PLAYER_HEIGHT = 'PlayerHeight'
-except:
-    pass
-
-try:
-    OVR_KEY_EYE_HEIGHT = 'EyeHeight'
-except:
-    pass
-
-try:
-    OVR_KEY_IPD = "IPD"
-except:
-    pass
-
-try:
-    OVR_KEY_NECK_TO_EYE_DISTANCE = 'NeckEyeDistance'
-except:
-    pass
-
-try:
-    OVR_DEFAULT_GENDER = 'Unknown'
-except:
-    pass
-
-try:
-    OVR_DEFAULT_PLAYER_HEIGHT = 1.778
-except:
-    pass
-
-try:
-    OVR_DEFAULT_EYE_HEIGHT = 1.675
-except:
-    pass
-
-try:
-    OVR_DEFAULT_IPD = 0.064
-except:
-    pass
-
-try:
-    OVR_DEFAULT_NECK_TO_EYE_HORIZONTAL = 0.0805
-except:
-    pass
-
-try:
-    OVR_DEFAULT_NECK_TO_EYE_VERTICAL = 0.075
-except:
-    pass
-
-try:
-    OVR_DEFAULT_EYE_RELIEF_DIAL = 3
-except:
-    pass
 
 
 # Run test program

--- a/ovr/__init__.py
+++ b/ovr/__init__.py
@@ -6,7 +6,7 @@ Works on Windows only at the moment (just like Oculus Rift SDK...)
 """
 
 import ctypes
-from ctypes import byref
+from ctypes import *
 import sys
 import textwrap
 import math
@@ -199,6 +199,9 @@ class Quatf(ctypes.Structure):
     def __repr__(self):
         return "ovr.Quatf(%s, %s, %s, %s)" % (self.x, self.y, self.z, self.w)
 
+    def toList(self):
+      return (self.w, self.x, self.y, self.z)
+
     def getEulerAngles(self, axis1=0, axis2=1, axis3=2, rotate_direction=1, handedness=1):
         assert(axis1 != axis2)
         assert(axis1 != axis3)
@@ -249,6 +252,9 @@ class Vector2f(ctypes.Structure):
     def __repr__(self):
         return "ovr.Vector2f(%s, %s)" % (self.x, self.y)
 
+    def toList(self):
+      return (self.x, self.y)
+
 
 # Translated from header file OVR_CAPI_0_7_0.h line 316
 class Vector3f(ctypes.Structure):
@@ -263,6 +269,8 @@ class Vector3f(ctypes.Structure):
     def __repr__(self):
         return "ovr.Vector3f(%s, %s, %s)" % (self.x, self.y, self.z)
 
+    def toList(self):
+      return (self.x, self.y, self.z)
 
 # Translated from header file OVR_CAPI_0_7_0.h line 322
 class Matrix4f(ctypes.Structure):
@@ -274,6 +282,17 @@ class Matrix4f(ctypes.Structure):
 
     def __repr__(self):
         return "ovr.Matrix4f(%s)" % (self.M)
+      
+    def toList(self, Transpose = False):
+      mm = []
+      for i in range(0, 4):
+        for j in range(0, 4):
+          if (Transpose):
+            mm.append(self.M[i][j])
+          else:
+            mm.append(self.M[j][i])
+      return tuple(mm)
+      
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 329
@@ -1705,6 +1724,241 @@ def resetMulticameraTracking(hmd):
     return result
 
 
+
+class UserString:
+    def __init__(self, seq):
+        if isinstance(seq, basestring):
+            self.data = seq
+        elif isinstance(seq, UserString):
+            self.data = seq.data[:]
+        else:
+            self.data = str(seq)
+    def __str__(self): return str(self.data)
+    def __repr__(self): return repr(self.data)
+    def __int__(self): return int(self.data)
+    def __long__(self): return long(self.data)
+    def __float__(self): return float(self.data)
+    def __complex__(self): return complex(self.data)
+    def __hash__(self): return hash(self.data)
+
+    def __cmp__(self, string):
+        if isinstance(string, UserString):
+            return cmp(self.data, string.data)
+        else:
+            return cmp(self.data, string)
+    def __contains__(self, char):
+        return char in self.data
+
+    def __len__(self): return len(self.data)
+    def __getitem__(self, index): return self.__class__(self.data[index])
+    def __getslice__(self, start, end):
+        start = max(start, 0); end = max(end, 0)
+        return self.__class__(self.data[start:end])
+
+    def __add__(self, other):
+        if isinstance(other, UserString):
+            return self.__class__(self.data + other.data)
+        elif isinstance(other, basestring):
+            return self.__class__(self.data + other)
+        else:
+            return self.__class__(self.data + str(other))
+    def __radd__(self, other):
+        if isinstance(other, basestring):
+            return self.__class__(other + self.data)
+        else:
+            return self.__class__(str(other) + self.data)
+    def __mul__(self, n):
+        return self.__class__(self.data*n)
+    __rmul__ = __mul__
+    def __mod__(self, args):
+        return self.__class__(self.data % args)
+
+    # the following methods are defined in alphabetical order:
+    def capitalize(self): return self.__class__(self.data.capitalize())
+    def center(self, width, *args):
+        return self.__class__(self.data.center(width, *args))
+    def count(self, sub, start=0, end=sys.maxint):
+        return self.data.count(sub, start, end)
+    def decode(self, encoding=None, errors=None): # XXX improve this?
+        if encoding:
+            if errors:
+                return self.__class__(self.data.decode(encoding, errors))
+            else:
+                return self.__class__(self.data.decode(encoding))
+        else:
+            return self.__class__(self.data.decode())
+    def encode(self, encoding=None, errors=None): # XXX improve this?
+        if encoding:
+            if errors:
+                return self.__class__(self.data.encode(encoding, errors))
+            else:
+                return self.__class__(self.data.encode(encoding))
+        else:
+            return self.__class__(self.data.encode())
+    def endswith(self, suffix, start=0, end=sys.maxint):
+        return self.data.endswith(suffix, start, end)
+    def expandtabs(self, tabsize=8):
+        return self.__class__(self.data.expandtabs(tabsize))
+    def find(self, sub, start=0, end=sys.maxint):
+        return self.data.find(sub, start, end)
+    def index(self, sub, start=0, end=sys.maxint):
+        return self.data.index(sub, start, end)
+    def isalpha(self): return self.data.isalpha()
+    def isalnum(self): return self.data.isalnum()
+    def isdecimal(self): return self.data.isdecimal()
+    def isdigit(self): return self.data.isdigit()
+    def islower(self): return self.data.islower()
+    def isnumeric(self): return self.data.isnumeric()
+    def isspace(self): return self.data.isspace()
+    def istitle(self): return self.data.istitle()
+    def isupper(self): return self.data.isupper()
+    def join(self, seq): return self.data.join(seq)
+    def ljust(self, width, *args):
+        return self.__class__(self.data.ljust(width, *args))
+    def lower(self): return self.__class__(self.data.lower())
+    def lstrip(self, chars=None): return self.__class__(self.data.lstrip(chars))
+    def partition(self, sep):
+        return self.data.partition(sep)
+    def replace(self, old, new, maxsplit=-1):
+        return self.__class__(self.data.replace(old, new, maxsplit))
+    def rfind(self, sub, start=0, end=sys.maxint):
+        return self.data.rfind(sub, start, end)
+    def rindex(self, sub, start=0, end=sys.maxint):
+        return self.data.rindex(sub, start, end)
+    def rjust(self, width, *args):
+        return self.__class__(self.data.rjust(width, *args))
+    def rpartition(self, sep):
+        return self.data.rpartition(sep)
+    def rstrip(self, chars=None): return self.__class__(self.data.rstrip(chars))
+    def split(self, sep=None, maxsplit=-1):
+        return self.data.split(sep, maxsplit)
+    def rsplit(self, sep=None, maxsplit=-1):
+        return self.data.rsplit(sep, maxsplit)
+    def splitlines(self, keepends=0): return self.data.splitlines(keepends)
+    def startswith(self, prefix, start=0, end=sys.maxint):
+        return self.data.startswith(prefix, start, end)
+    def strip(self, chars=None): return self.__class__(self.data.strip(chars))
+    def swapcase(self): return self.__class__(self.data.swapcase())
+    def title(self): return self.__class__(self.data.title())
+    def translate(self, *args):
+        return self.__class__(self.data.translate(*args))
+    def upper(self): return self.__class__(self.data.upper())
+    def zfill(self, width): return self.__class__(self.data.zfill(width))
+
+class MutableString(UserString):
+    """mutable string objects
+
+    Python strings are immutable objects.  This has the advantage, that
+    strings may be used as dictionary keys.  If this property isn't needed
+    and you insist on changing string values in place instead, you may cheat
+    and use MutableString.
+
+    But the purpose of this class is an educational one: to prevent
+    people from inventing their own mutable string class derived
+    from UserString and than forget thereby to remove (override) the
+    __hash__ method inherited from UserString.  This would lead to
+    errors that would be very hard to track down.
+
+    A faster and better solution is to rewrite your program using lists."""
+    def __init__(self, string=""):
+        self.data = string
+    def __hash__(self):
+        raise TypeError("unhashable type (it is mutable)")
+    def __setitem__(self, index, sub):
+        if index < 0:
+            index += len(self.data)
+        if index < 0 or index >= len(self.data): raise IndexError
+        self.data = self.data[:index] + sub + self.data[index+1:]
+    def __delitem__(self, index):
+        if index < 0:
+            index += len(self.data)
+        if index < 0 or index >= len(self.data): raise IndexError
+        self.data = self.data[:index] + self.data[index+1:]
+    def __setslice__(self, start, end, sub):
+        start = max(start, 0); end = max(end, 0)
+        if isinstance(sub, UserString):
+            self.data = self.data[:start]+sub.data+self.data[end:]
+        elif isinstance(sub, basestring):
+            self.data = self.data[:start]+sub+self.data[end:]
+        else:
+            self.data =  self.data[:start]+str(sub)+self.data[end:]
+    def __delslice__(self, start, end):
+        start = max(start, 0); end = max(end, 0)
+        self.data = self.data[:start] + self.data[end:]
+    def immutable(self):
+        return UserString(self.data)
+    def __iadd__(self, other):
+        if isinstance(other, UserString):
+            self.data += other.data
+        elif isinstance(other, basestring):
+            self.data += other
+        else:
+            self.data += str(other)
+        return self
+    def __imul__(self, n):
+        self.data *= n
+        return self
+
+def POINTER(obj):
+    p = ctypes.POINTER(obj)
+
+    # Convert None to a real NULL pointer to work around bugs
+    # in how ctypes handles None on 64-bit platforms
+    if not isinstance(p.from_param, classmethod):
+        def from_param(cls, x):
+            if x is None:
+                return cls()
+            else:
+                return x
+        p.from_param = classmethod(from_param)
+
+    return p
+      
+class String(MutableString, Union):
+
+    _fields_ = [('raw', POINTER(c_char)),
+                ('data', c_char_p)]
+
+    def __init__(self, obj=""):
+        if isinstance(obj, (str, unicode, UserString)):
+            self.data = str(obj)
+        else:
+            self.raw = obj
+
+    def __len__(self):
+        return self.data and len(self.data) or 0
+
+    def from_param(cls, obj):
+        # Convert None or 0
+        if obj is None or obj == 0:
+            return cls(POINTER(c_char)())
+
+        # Convert from String
+        elif isinstance(obj, String):
+            return obj
+
+        # Convert from str
+        elif isinstance(obj, str):
+            return cls(obj)
+
+        # Convert from c_char_p
+        elif isinstance(obj, c_char_p):
+            return obj
+
+        # Convert from POINTER(c_char)
+        elif isinstance(obj, POINTER(c_char)):
+            return obj
+
+        # Convert from raw pointer
+        elif isinstance(obj, int):
+            return cls(cast(obj, POINTER(c_char)))
+
+        # Convert from object
+        else:
+            return String.from_param(obj._as_parameter_)
+    from_param = classmethod(from_param)
+
+
 # Translated from header file OVR_CAPI_0_7_0.h line 1678
 libovr.ovr_GetBool.restype = Bool
 libovr.ovr_GetBool.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), Bool]
@@ -1777,8 +2031,9 @@ def setInt(hmd, propertyName, value):
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1719
-libovr.ovr_GetFloat.restype = ctypes.c_float
-libovr.ovr_GetFloat.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.c_float]
+libovr.ovr_GetFloat.restype = c_float
+libovr.ovr_GetFloat.argtypes = [Hmd, String, c_float]
+
 def getFloat(hmd, propertyName, defaultVal):
     """
     Reads a float property.
@@ -1789,7 +2044,7 @@ def getFloat(hmd, propertyName, defaultVal):
     \return Returns the property interpreted as an float value. Returns defaultVal if
             the property doesn't exist.
     """
-    result = libovr.ovr_GetFloat(hmd, None if propertyName is None else byref(propertyName), defaultVal)
+    result = libovr.ovr_GetFloat(hmd, None if propertyName is None else propertyName, defaultVal)
     return result
 
 
@@ -2037,8 +2292,80 @@ def matrix4f_Projection(fov, znear, zfar, projectionModFlags):
     
     \see ovrProjectionModifier
     """
-    result = libovr.ovrMatrix4f_Projection(fov, znear, zfar, projectionModFlags)
-    return result
+    #result = libovr.ovrMatrix4f_Projection(fov, znear, zfar, projectionModFlags)
+    #return result
+    rightHanded    = (projectionModFlags & Projection_RightHanded) > 0
+    flipZ          = (projectionModFlags & Projection_FarLessThanNear) > 0
+    farAtInfinity  = (projectionModFlags & Projection_FarClipAtInfinity) > 0
+    isOpenGL       = (projectionModFlags & Projection_ClipRangeOpenGL) > 0
+
+    if farAtInfinity and not flipZ :
+        farAtInfinity = False;
+
+    projXScale = 2.0 / ( fov.LeftTan + fov.RightTan )
+    projXOffset = ( fov.LeftTan - fov.RightTan ) * projXScale * 0.5
+    projYScale = 2.0 / ( fov.UpTan + fov.DownTan )
+    projYOffset = ( fov.UpTan - fov.DownTan ) * projYScale * 0.5
+
+    scale = Vector2f(projXScale, projYScale)
+    offset = Vector2f(projXOffset, projYOffset)
+    handednessScale = 1.0
+    if rightHanded:
+      handednessScale = -1.0
+
+    zscale = 1.0
+    if flipZ:
+      zscale = -1.0
+
+    projection = Matrix4f()
+    # Produces X result, mapping clip edges to [-w,+w]
+    projection.M[0][0] = scale.x
+    projection.M[0][1] = 0.0
+    projection.M[0][2] = handednessScale * offset.x
+    projection.M[0][3] = 0.0
+
+    # Produces Y result, mapping clip edges to [-w,+w]
+    # Hey - why is that YOffset negated?
+    # It's because a projection matrix transforms from world coords with Y=up,
+    # whereas this is derived from an NDC scaling, which is Y=down.
+    projection.M[1][0] = 0.0
+    projection.M[1][1] = scale.y
+    projection.M[1][2] = handednessScale * -offset.y
+    projection.M[1][3] = 0.0
+
+    # Produces Z-buffer result - app needs to fill this in with whatever Z range it wants.
+    # We'll just use some defaults for now.
+    projection.M[2][0] = 0.0
+    projection.M[2][1] = 0.0
+
+    if farAtInfinity:
+      if isOpenGL:
+        # It's not clear this makes sense for OpenGL - you don't get the same precision benefits you do in D3D.
+        projection.M[2][2] = -handednessScale
+        projection.M[2][3] = 2.0 * znear
+      else:
+        projection.M[2][2] = 0.0;
+        projection.M[2][3] = znear;
+    else:
+      if isOpenGL:
+        # Clip range is [-w,+w], so 0 is at the middle of the range.
+        projection.M[2][2] = -handednessScale * zscale * (znear + zfar) / (znear - zfar);
+        projection.M[2][3] = 2.0 * zscale * zfar * znear / (znear - zfar);
+      else:
+        # Clip range is [0,+w], so 0 is at the start of the range.
+        near = -znear;
+        if flipZ:
+          near = zfar;
+        projection.M[2][2] = -handednessScale * near / (znear - zfar);
+        projection.M[2][3] = zscale * zfar * znear / (znear - zfar);
+
+    # Produces W result (= Z in)
+    projection.M[3][0] = 0.0;
+    projection.M[3][1] = 0.0;
+    projection.M[3][2] = handednessScale;
+    projection.M[3][3] = 0.0;
+
+    return projection;
 
 
 # Translated from header file OVR_CAPI_Util.h line 61
@@ -2150,7 +2477,7 @@ except:
     pass
 
 try:
-    OVR_KEY_IPD = 'IPD'
+    OVR_KEY_IPD = "IPD"
 except:
     pass
 
@@ -2219,3 +2546,50 @@ if __name__ == "__main__":
 
     destroy(hmd)
     shutdown()
+
+
+class Rift():
+    @staticmethod
+    def initialize():
+        if (0 == initialize()):
+            raise SystemError("Unable to initialize the Oculus SDK")
+
+    @staticmethod
+    def shutdown():
+        shutdown()
+
+    def __init__(self, index = 0):
+        self.hmd, self.luid = create()
+
+    def destroy(self):
+        destroy(self.hmd)
+        self.hmd = None
+
+    def get_last_error(self):
+        return getLastErrorInfo(self.hmd);
+
+    def configure_tracking(self, supported_caps = 
+                     TrackingCap_Orientation |
+                     TrackingCap_MagYawCorrection |
+                     TrackingCap_Position, 
+                     required_caps = 0):
+        configureTracking(self.hmd, supported_caps, required_caps)
+
+    def recenter_pose(self):
+        return recenterPose(self.hmd)
+
+    def get_tracking_state(self, absTime = 0):
+        return getTrackingState(self.hmd, absTime)
+
+    def get_fov_texture_size(self, eye, fov_port, pixels_per_display_pixel = 1.0):
+        return getFovTextureSize(self.hmd, eye, fov_port, pixels_per_display_pixel);
+
+    @staticmethod
+    def get_perspective(fov, near, far, right_handed):
+        return matrix4f_Projection(fov, near, far, '\x01' if right_handed else '\x00')
+
+    def get_float(self, name, default):
+        return getFloat(self.hmd, name, default)
+
+    def get_string(self, name, default):
+        return getString(self.hmd, name, default)

--- a/ovr/__init__.py
+++ b/ovr/__init__.py
@@ -1961,7 +1961,7 @@ class String(MutableString, Union):
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1678
 libovr.ovr_GetBool.restype = Bool
-libovr.ovr_GetBool.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), Bool]
+libovr.ovr_GetBool.argtypes = [Hmd, String, Bool]
 def getBool(hmd, propertyName, defaultVal):
     """
     Reads a boolean property.
@@ -1972,13 +1972,13 @@ def getBool(hmd, propertyName, defaultVal):
     \return Returns the property interpreted as a boolean value. Returns defaultVal if
             the property doesn't exist.
     """
-    result = libovr.ovr_GetBool(hmd, None if propertyName is None else byref(propertyName), defaultVal)
+    result = libovr.ovr_GetBool(hmd, None if propertyName is None else propertyName, defaultVal)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1687
 libovr.ovr_SetBool.restype = Bool
-libovr.ovr_SetBool.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), Bool]
+libovr.ovr_SetBool.argtypes = [Hmd, String, Bool]
 def setBool(hmd, propertyName, value):
     """
     Writes or creates a boolean property.
@@ -1990,13 +1990,13 @@ def setBool(hmd, propertyName, value):
     \return Returns true if successful, otherwise false. A false result should only occur if the property
             name is empty or if the property is read-only.
     """
-    result = libovr.ovr_SetBool(hmd, None if propertyName is None else byref(propertyName), value)
+    result = libovr.ovr_SetBool(hmd, None if propertyName is None else propertyName, value)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1698
 libovr.ovr_GetInt.restype = ctypes.c_int
-libovr.ovr_GetInt.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.c_int]
+libovr.ovr_GetInt.argtypes = [Hmd, String, ctypes.c_int]
 def getInt(hmd, propertyName, defaultVal):
     """
     Reads an integer property.
@@ -2007,13 +2007,13 @@ def getInt(hmd, propertyName, defaultVal):
     \return Returns the property interpreted as an integer value. Returns defaultVal if
             the property doesn't exist.
     """
-    result = libovr.ovr_GetInt(hmd, None if propertyName is None else byref(propertyName), defaultVal)
+    result = libovr.ovr_GetInt(hmd, None if propertyName is None else propertyName, defaultVal)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1707
 libovr.ovr_SetInt.restype = Bool
-libovr.ovr_SetInt.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.c_int]
+libovr.ovr_SetInt.argtypes = [Hmd, String, ctypes.c_int]
 def setInt(hmd, propertyName, value):
     """
     Writes or creates an integer property.
@@ -2026,14 +2026,13 @@ def setInt(hmd, propertyName, value):
     \return Returns true if successful, otherwise false. A false result should only occur if the property
             name is empty or if the property is read-only.
     """
-    result = libovr.ovr_SetInt(hmd, None if propertyName is None else byref(propertyName), value)
+    result = libovr.ovr_SetInt(hmd, None if propertyName is None else propertyName, value)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1719
-libovr.ovr_GetFloat.restype = c_float
-libovr.ovr_GetFloat.argtypes = [Hmd, String, c_float]
-
+libovr.ovr_GetFloat.restype = ctypes.c_float
+libovr.ovr_GetFloat.argtypes = [Hmd, String, ctypes.c_float]
 def getFloat(hmd, propertyName, defaultVal):
     """
     Reads a float property.
@@ -2050,7 +2049,7 @@ def getFloat(hmd, propertyName, defaultVal):
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1728
 libovr.ovr_SetFloat.restype = Bool
-libovr.ovr_SetFloat.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.c_float]
+libovr.ovr_SetFloat.argtypes = [Hmd, String, ctypes.c_float]
 def setFloat(hmd, propertyName, value):
     """
     Writes or creates a float property.
@@ -2062,13 +2061,13 @@ def setFloat(hmd, propertyName, value):
     \return Returns true if successful, otherwise false. A false result should only occur if the property
             name is empty or if the property is read-only.
     """
-    result = libovr.ovr_SetFloat(hmd, None if propertyName is None else byref(propertyName), value)
+    result = libovr.ovr_SetFloat(hmd, None if propertyName is None else propertyName, value)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1739
 libovr.ovr_GetFloatArray.restype = ctypes.c_uint
-libovr.ovr_GetFloatArray.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_float), ctypes.c_uint]
+libovr.ovr_GetFloatArray.argtypes = [Hmd, String, ctypes.POINTER(ctypes.c_float), ctypes.c_uint]
 def getFloatArray(hmd, propertyName, values, valuesCapacity):
     """
     Reads a float array property.
@@ -2079,13 +2078,13 @@ def getFloatArray(hmd, propertyName, values, valuesCapacity):
     \param[in] valuesCapacity Specifies the maximum number of elements to write to the values array.
     \return Returns the number of elements read, or 0 if property doesn't exist or is empty.
     """
-    result = libovr.ovr_GetFloatArray(hmd, None if propertyName is None else byref(propertyName), None if values is None else byref(values), valuesCapacity)
+    result = libovr.ovr_GetFloatArray(hmd, None if propertyName is None else propertyName, None if values is None else byref(values), valuesCapacity)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1749
 libovr.ovr_SetFloatArray.restype = Bool
-libovr.ovr_SetFloatArray.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_float), ctypes.c_uint]
+libovr.ovr_SetFloatArray.argtypes = [Hmd, String, ctypes.POINTER(ctypes.c_float), ctypes.c_uint]
 def setFloatArray(hmd, propertyName, values, valuesSize):
     """
     Writes or creates a float array property.
@@ -2097,13 +2096,13 @@ def setFloatArray(hmd, propertyName, values, valuesSize):
     \return Returns true if successful, otherwise false. A false result should only occur if the property
             name is empty or if the property is read-only.
     """
-    result = libovr.ovr_SetFloatArray(hmd, None if propertyName is None else byref(propertyName), None if values is None else byref(values), valuesSize)
+    result = libovr.ovr_SetFloatArray(hmd, None if propertyName is None else propertyName, None if values is None else byref(values), valuesSize)
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1761
 libovr.ovr_GetString.restype = ctypes.POINTER(ctypes.c_char)
-libovr.ovr_GetString.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char)]
+libovr.ovr_GetString.argtypes = [Hmd, String, ctypes.POINTER(ctypes.c_char)]
 def getString(hmd, propertyName, defaultVal):
     """
     Reads a string property.
@@ -2116,13 +2115,13 @@ def getString(hmd, propertyName, defaultVal):
             The return memory is guaranteed to be valid until next call to ovr_GetString or
             until the HMD is destroyed, whichever occurs first.
     """
-    result = libovr.ovr_GetString(hmd, None if propertyName is None else byref(propertyName), None if defaultVal is None else byref(defaultVal))
+    result = libovr.ovr_GetString(hmd, None if propertyName is None else propertyName, None if defaultVal is None else byref(defaultVal))
     return result
 
 
 # Translated from header file OVR_CAPI_0_7_0.h line 1773
 libovr.ovr_SetString.restype = Bool
-libovr.ovr_SetString.argtypes = [Hmd, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char)]
+libovr.ovr_SetString.argtypes = [Hmd, String, ctypes.POINTER(ctypes.c_char)]
 def setString(hmd, propertyName, value):
     """
     Writes or creates a string property.
@@ -2134,7 +2133,7 @@ def setString(hmd, propertyName, value):
     \return Returns true if successful, otherwise false. A false result should only occur if the property
             name is empty or if the property is read-only.
     """
-    result = libovr.ovr_SetString(hmd, None if propertyName is None else byref(propertyName), None if value is None else byref(value))
+    result = libovr.ovr_SetString(hmd, None if propertyName is None else propertyName, None if value is None else byref(value))
     return result
 
 
@@ -2547,49 +2546,3 @@ if __name__ == "__main__":
     destroy(hmd)
     shutdown()
 
-
-class Rift():
-    @staticmethod
-    def initialize():
-        if (0 == initialize()):
-            raise SystemError("Unable to initialize the Oculus SDK")
-
-    @staticmethod
-    def shutdown():
-        shutdown()
-
-    def __init__(self, index = 0):
-        self.hmd, self.luid = create()
-
-    def destroy(self):
-        destroy(self.hmd)
-        self.hmd = None
-
-    def get_last_error(self):
-        return getLastErrorInfo(self.hmd);
-
-    def configure_tracking(self, supported_caps = 
-                     TrackingCap_Orientation |
-                     TrackingCap_MagYawCorrection |
-                     TrackingCap_Position, 
-                     required_caps = 0):
-        configureTracking(self.hmd, supported_caps, required_caps)
-
-    def recenter_pose(self):
-        return recenterPose(self.hmd)
-
-    def get_tracking_state(self, absTime = 0):
-        return getTrackingState(self.hmd, absTime)
-
-    def get_fov_texture_size(self, eye, fov_port, pixels_per_display_pixel = 1.0):
-        return getFovTextureSize(self.hmd, eye, fov_port, pixels_per_display_pixel);
-
-    @staticmethod
-    def get_perspective(fov, near, far, right_handed):
-        return matrix4f_Projection(fov, near, far, '\x01' if right_handed else '\x00')
-
-    def get_float(self, name, default):
-        return getFloat(self.hmd, name, default)
-
-    def get_string(self, name, default):
-        return getString(self.hmd, name, default)


### PR DESCRIPTION
* allow python native strings to be used in the get/set methods of the ovr library (getFloat, setFloat, etc)
* Additional example code using pygame
* Fixing the use of `format` in a variable name, which triggers a warning
* adding toList methods to OVR math types for easy porting to cgkit types.
    
