### PR TITLE
Updating demo, adding new wrapper

### DIFF
--- a/examples/pygame/RiftApp.py
+++ b/examples/pygame/RiftApp.py
@@ -1,151 +1,174 @@
 import ovr
 import pygame
 import pygame.locals as pgl
+from ovr.rift import Rift
+from OpenGL.GL import *    #@UnusedWildImport
 
-from OpenGL.GL import *
+class RiftSwapFramebuffer():
+  def __init__(self, rift, size, format_ = GL_RGBA8):
+    self.rift = rift
+    self.depth = 0
+    self.size = size
+    self.format = format_
+    self.fbo = 0
+    self.build()
+
+  def __getCurrentGLTexture(self):
+    tsc = self.pTextureSet.contents
+    curTexturePointer = ctypes.addressof(tsc.Textures[tsc.CurrentIndex])
+    # Tricky casting here
+    texture = ctypes.cast(curTexturePointer, ctypes.POINTER(ovr.GLTexture)).contents
+    return texture
+    
+  def build(self, ):
+    self.pTextureSet = self.rift.create_swap_texture(self.size)
+    self.depth = glGenRenderbuffers(1)
+    # Set up the depth attachment renderbuffer
+    glBindRenderbuffer(GL_RENDERBUFFER, self.depth)
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, self.size.w, self.size.h)
+    glBindRenderbuffer(GL_RENDERBUFFER, 0)
+
+    # Set up the framebuffer proper
+    self.fbo = glGenFramebuffers(1)
+    glBindFramebuffer(GL_FRAMEBUFFER, self.fbo)
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, self.depth)
+    glBindFramebuffer(GL_FRAMEBUFFER, 0)
+    
+  def destroy(self):
+    glDeleteFramebuffers(1, [self.fbo])
+    glDeleteRenderbuffers(1, [self.depth])
+    if self.pTextureSet is not None:
+      self.rift.destroy_swap_texture(self.pTextureSet)
+  
+  def attachCurrentTexture(self, target = GL_DRAW_FRAMEBUFFER):
+    texture = self.__getCurrentGLTexture()
+    # We switch textures every frame, so we need to bind the new texture here
+    glFramebufferTexture2D(target, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture.OGL.TexId, 0)
+
+    # FIXME? validating every frame may be excessive
+    fboStatus = glCheckFramebufferStatus(target)
+    if (GL_FRAMEBUFFER_COMPLETE != fboStatus):
+      raise Exception("Bad framebuffer setup")
+    
+  def bind(self, target = GL_DRAW_FRAMEBUFFER):
+    glBindFramebuffer(target, self.fbo)
+
+    
+  def unbind(self, target = GL_DRAW_FRAMEBUFFER):
+    glBindFramebuffer(target, 0)
+
+  def increment(self):
+    tsc = self.pTextureSet.contents
+    tsc.CurrentIndex = (tsc.CurrentIndex + 1) % tsc.TextureCount
+  
 
 class RiftApp():
   def __init__(self):
-    ovr.initialize(None)
-    self.hmd, self.luid = ovr.create()
-    self.hmdDesc = ovr.getHmdDesc(self.hmd)
+    Rift.initialize()
+
+    self.rift = Rift()
+    self.rift.init()
     self.frame = 0
+    self.mirror = True
 
-    ovr.configureTracking(self.hmd, 
-        ovr.TrackingCap_Orientation | # supported capabilities
-        ovr.TrackingCap_MagYawCorrection |
-        ovr.TrackingCap_Position, 
-        0) # required capabilities
+    self.eyeRenderDescs = (ovr.EyeRenderDesc * 2)()
+    self.eyeOffsets = (ovr.Vector3f * 2)()
+    self.projections = (ovr.Matrix4f * 2)()
+    self.textureSizes = (ovr.Sizei * 2)()
+    self.fovPorts = (ovr.FovPort * 2)()
+    self.poses = (ovr.Posef * 2)()
+    self.bufferSize = ovr.Sizei()
+    self.viewScale = ovr.ViewScaleDesc()
+    self.viewScale.HmdSpaceToWorldScaleInMeters = 1.0
 
-    self.fovPorts = (
-      self.hmdDesc.DefaultEyeFov[0],
-      self.hmdDesc.DefaultEyeFov[1]
-    )
+    for eye in range(0, 2):
+      self.fovPorts[eye] = self.rift.hmdDesc.DefaultEyeFov[eye]
+      self.eyeRenderDescs[eye] = self.rift.get_render_desc(eye, self.fovPorts[eye]);
+      self.eyeOffsets[eye] = self.eyeRenderDescs[eye].HmdToEyeViewOffset
+      self.projections[eye] = Rift.get_perspective(self.fovPorts[eye], 0.01, 1000)
+      self.textureSizes[eye] = self.rift.get_fov_texture_size(eye, self.fovPorts[eye])
+      self.viewScale.HmdToEyeViewOffset[eye] = self.eyeOffsets[eye]
 
-    self.projections = map(
-      lambda fovPort:
-        (ovr.matrix4f_Projection(
-           fovPort, 0.01, 1000, True)),
-      self.fovPorts
-    )
+    self.bufferSize.w  = self.textureSizes[0].w + self.textureSizes[1].w
+    self.bufferSize.h = max ( self.textureSizes[0].h, self.textureSizes[1].h )
 
+    # TODO make the Rift wrapper class manage the layers and provide an API for enabling and disabling them
+    # Initialize our single full screen Fov layer.
+    layer = ovr.LayerEyeFov()
+    layer.Header.Type      = ovr.LayerType_EyeFov
+    layer.Header.Flags     = ovr.LayerFlag_TextureOriginAtBottomLeft # OpenGL convention
+    layer.Fov[0]           = self.fovPorts[0]
+    layer.Fov[1]           = self.fovPorts[1]
+    viewportSize = ovr.Sizei(self.bufferSize.w / 2, self.bufferSize.h)
+    viewportPos = ovr.Vector2i(0, 0)
+    layer.Viewport[0]      = ovr.Recti(viewportPos, viewportSize)
+    viewportPos = ovr.Vector2i(self.bufferSize.w / 2, 0)
+    layer.Viewport[1]      = ovr.Recti(viewportPos, viewportSize)
+    self.layer = layer
+
+    self.rift.configure_tracking()
+        
   def close(self):
-    glDeleteFramebuffers(1, [self.fbo])
-    # glDeleteTextures(self.color)
-    glDeleteRenderbuffers(1, [self.depth])
-    if self.pTextureSet is not None:
-        ovr.destroySwapTextureSet(self.hmd, self.pTextureSet)
-
-    ovr.destroy(self.hmd)
-    self.hmd = None
-    ovr.shutdown()
+    self.framebuffer.destroy()
+    self.rift.destroy()
+    self.rift = None
+    Rift.shutdown()
 
   def create_window(self):
     import os
     os.environ['SDL_VIDEO_WINDOW_POS'] = "%d,%d" % (100, 100)
     pygame.init()
-    pygame.display.set_mode(
-      (
-        self.hmdDesc.Resolution.w / 4,
-        self.hmdDesc.Resolution.h / 4
-      ),
-      pgl.HWSURFACE | pgl.OPENGL | pgl.NOFRAME)
+    resolution = self.rift.get_resolution()
+    resolution.w /= 4
+    resolution.h /= 4
+    self.windowSize = resolution 
+    # Note we DO NOT want double bufering here as that will trigger v-sync
+    flags = pgl.HWSURFACE | pgl.OPENGL | pgl.NOFRAME
+    size = (self.windowSize.w, self.windowSize.h)
+    pygame.display.set_mode(size, flags)
 
   def init_gl(self):
-
-    recommenedTex0Size = ovr.getFovTextureSize(self.hmd, ovr.Eye_Left, 
-            self.hmdDesc.DefaultEyeFov[0], 1.0)
-    
-    recommenedTex1Size = ovr.getFovTextureSize(self.hmd, ovr.Eye_Right,
-            self.hmdDesc.DefaultEyeFov[1], 1.0)
-    self.bufferSize = ovr.Sizei()
-    self.bufferSize.w  = recommenedTex0Size.w + recommenedTex1Size.w
-    self.bufferSize.h = max ( recommenedTex0Size.h, recommenedTex1Size.h )
-    print "Recommended buffer size = ", self.bufferSize, self.bufferSize.w, self.bufferSize.h
-    # NOTE: We need to have set up OpenGL context before this point...
-    # 1c) Allocate SwapTextureSets
-    self.pTextureSet = ovr.createSwapTextureSetGL(self.hmd,
-            GL_RGBA8, self.bufferSize.w, self.bufferSize.h)
-
-    # Initialize our single full screen Fov layer.
-    layer = ovr.LayerEyeFov()
-    layer.Header.Type      = ovr.LayerType_EyeFov
-    layer.Header.Flags     = ovr.LayerFlag_TextureOriginAtBottomLeft # OpenGL convention
-    layer.ColorTexture[0]  = self.pTextureSet # single texture for both eyes
-    layer.ColorTexture[1]  = self.pTextureSet # single texture for both eyes
-    layer.Fov[0]           = self.fovPorts[0]
-    layer.Fov[1]           = self.fovPorts[1]
-    layer.Viewport[0]      = ovr.Recti(ovr.Vector2i(0, 0), ovr.Sizei(self.bufferSize.w / 2, self.bufferSize.h))
-    layer.Viewport[1]      = ovr.Recti(ovr.Vector2i(self.bufferSize.w / 2, 0), ovr.Sizei(self.bufferSize.w / 2, self.bufferSize.h))
-    self.layer = layer
-
-    self.build_framebuffer();
-
-    self.eyeRenderDescs = [ ovr.EyeRenderDesc(), ovr.EyeRenderDesc() ];
-    self.eyeOffsets = (ovr.Vector3f * 2)();
-    for eye in range(0, 2):
-      self.eyeRenderDescs[eye] = ovr.getRenderDesc(self.hmd, eye, self.fovPorts[eye]);
-      self.eyeOffsets[eye] = self.eyeRenderDescs[eye].HmdToEyeViewOffset
-      
-  def build_framebuffer(self):
-    self.fbo = glGenFramebuffers(1)
-    self.depth = glGenRenderbuffers(1)
-    # Set up the depth attachment renderbuffer
-    glBindRenderbuffer(GL_RENDERBUFFER, self.depth)
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, 
-                          self.bufferSize.w, self.bufferSize.h)
-    glBindRenderbuffer(GL_RENDERBUFFER, 0)
-
-    # Set up the framebuffer proper
-    glBindFramebuffer(GL_FRAMEBUFFER, self.fbo)
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, self.depth)
-    glBindFramebuffer(GL_FRAMEBUFFER, 0)
-
-  def bind_framebuffer(self):
-      glBindFramebuffer(GL_FRAMEBUFFER, self.fbo)
-      tsc = self.pTextureSet.contents
-      texture = ctypes.cast(ctypes.addressof(tsc.Textures[tsc.CurrentIndex]), ctypes.POINTER(ovr.GLTexture)).contents
-      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture.OGL.TexId, 0)
-      fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER)
-      if (GL_FRAMEBUFFER_COMPLETE != fboStatus):
-        raise Exception("Bad framebuffer setup")
-  
-  def increment_framebuffer(self): 
-    tsc = self.pTextureSet.contents
-    tsc.CurrentIndex = (tsc.CurrentIndex + 1) % tsc.TextureCount
+    self.framebuffer = RiftSwapFramebuffer(self.rift, self.bufferSize)
+    self.layer.ColorTexture[0]  = self.framebuffer.pTextureSet # single texture for both eyes
+    self.layer.ColorTexture[1]  = self.framebuffer.pTextureSet # single texture for both eyes
 
   def submit_frame(self): 
     layers = self.layer.Header
-    viewScale = ovr.ViewScaleDesc()
-    viewScale.HmdSpaceToWorldScaleInMeters = 1.0
     for eye in range(0, 2):
       self.layer.RenderPose[eye] = self.poses[eye]
-      viewScale.HmdToEyeViewOffset[eye] = self.eyeOffsets[eye]
-    result = ovr.submitFrame(self.hmd, self.frame, viewScale, layers, 1)
+    self.rift.submit_frame(self.frame, self.viewScale, layers, 1)
 
   def render_frame(self):
     self.frame += 1
 
     # Fetch the head pose
-    self.poses = (ovr.Posef * 2)()
-    ovr.getEyePoses(self.hmd, self.frame, self.eyeOffsets, self.poses)
+    self.poses = self.rift.get_eye_poses(self.frame, self.eyeOffsets)
 
     # Active the offscreen framebuffer and render the scene
-    self.bind_framebuffer()
-
+    self.framebuffer.bind()
+    self.framebuffer.attachCurrentTexture()
     for eye in range(0, 2):
-      self.currentEye = eye;
+      self.currentEye = eye
       vp = self.layer.Viewport[eye]
       glViewport(vp.Pos.x, vp.Pos.y, vp.Size.w, vp.Size.h)
       glEnable(GL_SCISSOR_TEST)
       glScissor(vp.Pos.x, vp.Pos.y, vp.Size.w, vp.Size.h)
       self.render_scene()
-
-    self.currentEye = -1;
-    glBindFramebuffer(GL_FRAMEBUFFER, 0)
-    self.submit_frame();
-    self.increment_framebuffer();
-    glGetError()
+      
+    self.currentEye = -1
+    self.framebuffer.unbind()
+    # Optional, mirror to the screen
+    if self.mirror:
+      glDisable(GL_SCISSOR_TEST)
+      glViewport(0, 0, self.windowSize.w, self.windowSize.h)
+      glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT)
+      self.framebuffer.bind(GL_READ_FRAMEBUFFER)
+      glBlitFramebuffer(0, 0, self.framebuffer.size.w, self.framebuffer.size.h,
+                        0, 0, self.windowSize.w, self.windowSize.h, 
+                        GL_COLOR_BUFFER_BIT, GL_NEAREST)
+      self.framebuffer.unbind(GL_READ_FRAMEBUFFER)
+    self.submit_frame()
+    self.framebuffer.increment()
 
   def update(self):
     for event in pygame.event.get():

--- a/examples/pygame/RiftDemo.py
+++ b/examples/pygame/RiftDemo.py
@@ -5,7 +5,7 @@ import ovr
 
 from RiftApp import RiftApp
 from cgkit.cgtypes import mat4, vec3, quat
-from OpenGL.GL import *
+from OpenGL.GL import *   #@UnusedWildImport
 
 def ovrPoseToMat4(pose):
   # Apply the head orientation
@@ -25,7 +25,7 @@ def ovrPoseToMat4(pose):
   pose = pos * rot
   return pose
 
-
+# FIXME shitty non-Core profile rendering code
 def draw_color_cube(size=1.0):
   p = size / 2.0
   n = -p
@@ -73,8 +73,7 @@ def draw_color_cube(size=1.0):
 class RiftDemo(RiftApp):
   def __init__(self):
     RiftApp.__init__(self)
-    self.cube_size = ovr.getFloat(self.hmd, 
-      ovr.KEY_IPD, ovr.DEFAULT_IPD)
+    self.cube_size = self.rift.get_float(ovr.KEY_IPD, ovr.DEFAULT_IPD)
     self.reset_camera()
     
   def reset_camera(self):
@@ -82,7 +81,7 @@ class RiftDemo(RiftApp):
     self.camera.translate(vec3(0, 0, 0.2))
 
   def recompose_camera(self):
-    (tr, rot, sc) = self.camera.decompose()
+    (tr, rot, _) = self.camera.decompose()
     self.camera = mat4(1.0)
     self.camera.translate(tr)
     self.camera = self.camera * rot
@@ -113,7 +112,7 @@ class RiftDemo(RiftApp):
     # Modify direction vectors for key presses
     translation = vec3()
     if pressed[pgl.K_r]:
-      ovr.recenterPose(self.hmd)
+      self.rift.recenter_pose()
     if pressed[pgl.K_w]:
       translation.z = -1.0
     elif pressed[pgl.K_s]:
@@ -137,6 +136,7 @@ class RiftDemo(RiftApp):
     # apply the camera position
     cameraview = self.camera * eyeview  
 
+    # FIXME deprecated GL functions must die
     glMatrixMode(GL_PROJECTION)
     glLoadMatrixf(list(self.projections[eye]))
 

--- a/ovr/rift.py
+++ b/ovr/rift.py
@@ -1,0 +1,93 @@
+import ovr
+from OpenGL.GL import GL_RGBA8
+
+class Rift():
+    @staticmethod
+    def initialize(params=None):
+      return ovr.initialize(params)
+
+    @staticmethod
+    def shutdown():
+      ovr.shutdown()
+
+    @staticmethod
+    def get_last_error(self):
+      return ovr.getLastErrorInfo()
+
+    @staticmethod
+    def get_time_in_seconds():
+      return ovr.getTimeInSeconds()
+
+    @staticmethod
+    def get_perspective(fov, near, far, projectionFlags = ovr.Projection_RightHanded):
+      return ovr.matrix4f_Projection(fov, near, far, projectionFlags)
+
+    def __init__(self):
+      self.hmd = None
+      self.luid = None
+      self.hmdDesc = None
+
+    def __enter__(self):
+      self.init()
+      return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+      self.destroy()
+
+    def configure_tracking(self,
+                           supported_caps =
+                              ovr.TrackingCap_Orientation |
+                              ovr.TrackingCap_MagYawCorrection |
+                              ovr.TrackingCap_Position, 
+                           required_caps = 0):
+      return ovr.configureTracking(self.hmd, supported_caps, required_caps)
+
+
+    def init(self):
+      self.hmd, self.luid = ovr.create()
+      self.hmdDesc = ovr.getHmdDesc(self.hmd)
+
+    def destroy(self):
+      if self.hmd is not None:
+        ovr.destroy(self.hmd)
+      self.hmd = None
+      self.luid = None
+      self.hmdDesc = None
+      self.hmd = None
+
+    def recenter_pose(self):
+      return ovr.recenterPose(self.hmd)
+
+    def get_tracking_state(self, absTime=0):
+      return ovr.getTrackingState(self.hmd, absTime)
+
+    def get_fov_texture_size(self, eye, fov_port, pixels_per_display_pixel=1.0):
+      return ovr.getFovTextureSize(self.hmd, eye, fov_port, pixels_per_display_pixel);
+
+    def get_eye_poses(self, frame_index, eyeOffsets, trackingState=0):
+      in_arr = (ovr.Vector3f * 2)(*eyeOffsets)
+      out_arr = (ovr.Posef * 2)()
+      ovr.getEyePoses(self.hmd, frame_index, in_arr, out_arr)
+      return out_arr;
+
+    def create_swap_texture(self, size, format_ = GL_RGBA8):
+      return ovr.createSwapTextureSetGL(self.hmd, format_, size.w, size.h)
+
+    def destroy_swap_texture(self, textureSet):
+      return ovr.destroySwapTextureSet(self.hmd, textureSet)
+
+    def get_render_desc(self, eye, fov):
+      return ovr.getRenderDesc(self.hmd, eye, fov)
+
+    def get_float(self, name, default):
+      return ovr.getFloat(self.hmd, name, default)
+
+    def get_string(self, name, default):
+      return ovr.getString(self.hmd, name, default)
+
+    def get_resolution(self):
+      return self.hmdDesc.Resolution
+
+    def submit_frame(self, frameIndex, viewScaleDesc, layerPtrList, layerCount):
+      return ovr.submitFrame(self.hmd, frameIndex, viewScaleDesc, layerPtrList, layerCount)
+


### PR DESCRIPTION
This updates the demo code to use a new wrapper I've created, based partially on my wrapper in my old bindings, and partially on the hmd_wrapper in the new bindings.  The intent is to let the user ignore the C API completely and use the wrapper to interact with the SDK in an object oriented manner with Python idioms in mind.

I've also created a wrapper for using a SwapTextureSet in conjunction with an OpenGL framebuffer, minimizing the amount of code required for a caller to create and use the framebuffer.  This is currently in the pygame RiftApp example base class, but might be well suited to being moved to the ovr/rift.py class, although it introduces a dependency on the OpenGL imports.

Additionally, I've updated the Pygame example to use this wrapper exclusively, as well as re-organizing the code to perform all non-GL dependent work in the constructor.  